### PR TITLE
Add CSV stats tutorial and fix README

### DIFF
--- a/08_CSV_Statistics.ipynb
+++ b/08_CSV_Statistics.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "09b695c0",
+   "metadata": {},
+   "source": [
+    "# Cargar CSV y calcular estadisticas basicas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d8c43c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder.appName(\"CSVStats\").getOrCreate()\n",
+    "\n",
+    "# Cargar CSV en DataFrame\n",
+    "df = spark.read.csv(\"ruta/al/archivo.csv\", header=True, inferSchema=True)\n",
+    "\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "367af678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql.functions import mean, expr, stddev\n",
+    "\n",
+    "# Calcular estadisticas\n",
+    "stats_df = df.select(\n",
+    "    mean(\"columna\").alias(\"media\"),\n",
+    "    expr(\"percentile_approx(columna, 0.5)\").alias(\"mediana\"),\n",
+    "    stddev(\"columna\").alias(\"desviacion_estandar\")\n",
+    ")\n",
+    "\n",
+    "stats_df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4d4da3a",
+   "metadata": {},
+   "source": [
+    "En este tutorial se explica como cargar datos desde un archivo CSV a un DataFrame de Spark y calcular estadísticas básicas como la media, mediana y desviación estándar de una columna numérica."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # apache_spark_lessons
-Seven  notebooks to learn from scratch Apache Spark
+Eight notebooks to learn Apache Spark from scratch


### PR DESCRIPTION
## Summary
- corregir la redacción del README en la línea 2 para indicar que ahora hay ocho notebooks
- añadir el cuaderno `08_CSV_Statistics.ipynb` con un ejemplo de carga de CSV y cálculo de estadísticas básicas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f9474b8988333a31d7b06a3b0e1a2