### PR TITLE
Fix typo in MLlib notebook

### DIFF
--- a/05_Spark_MLlib.ipynb
+++ b/05_Spark_MLlib.ipynb
@@ -301,7 +301,7 @@
     "\n",
     "Los árboles de decisión son uno de los algoritmos más intuitivos y populares en aprendizaje automático. Son estructuras de árbol donde cada nodo representa una característica (o atributo), cada enlace (o rama) representa una decisión (regla) sobre la característica, y cada hoja representa un resultado (categoría o valor continuo, dependiendo de si es clasificación o regresión).\n",
     "\n",
-    "Spark MLlib proporciona un implementación eficiente de árboles de decisión para clasificación y regresión.\n"
+    "Spark MLlib proporciona una implementación eficiente de árboles de decisión para clasificación y regresión.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix article usage in MLlib decision trees section

## Testing
- `grep -n "Spark MLlib proporciona" -n 05_Spark_MLlib.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68433ed445e083339f9c306644b29932